### PR TITLE
Implemented ConfirmChannel typings for promise API

### DIFF
--- a/channel_api.d.ts
+++ b/channel_api.d.ts
@@ -10,7 +10,7 @@ export import Message = shared.Message;
 export interface Connection extends events.EventEmitter {
     close(): when.Promise<void>;
     createChannel(): when.Promise<Channel>;
-    createConfirmChannel(): when.Promise<Channel>;
+    createConfirmChannel(): when.Promise<ConfirmChannel>;
 }
 
 export interface Channel extends events.EventEmitter {
@@ -50,6 +50,13 @@ export interface Channel extends events.EventEmitter {
 
     prefetch(count: number, global?: boolean): when.Promise<Replies.Empty>;
     recover(): when.Promise<Replies.Empty>;
+}
+
+export interface ConfirmChannel extends Channel {
+    publish(exchange:string, routingKey:string, content:Buffer, options?:Options.Publish, callback?:(err:any, ok:Replies.Empty) => void):boolean;
+    sendToQueue(queue:string, content:Buffer, options?:Options.Publish, callback?:(err:any, ok:Replies.Empty) => void):boolean;
+
+    waitForConfirms(): when.Promise<void>;
 }
 
 export function connect(url: string, socketOptions?: any): when.Promise<Connection>;


### PR DESCRIPTION
http://www.squaremobius.net/amqp.node/channel_api.html#confirmchannel
The channel (promise) API also implements ConfirmChannel, with publish
and sendToQueue accepting a callback. waitForConfirms returns a promise.
